### PR TITLE
Add note about elixir filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ To open your coc-settings file directly from Vim or Nvim, you can use this comma
 
 Doing these steps should make this plugin work with [CoC](https://github.com/neoclide/coc.nvim).
 
+### coc-elixir is installed correctly but doesn't work
+
+Make sure `filetype` is set to `elixir`, or install [vim-elixir](https://github.com/elixir-editors/vim-elixir) which sets up file extension associations and syntax highlighting.
+
 ## License
 
 MIT


### PR DESCRIPTION
Added note about elixir filetype having to be set and a tip to use vim-elixir, as coc-elixir didn't work out of the box.

Thanks to @amiralies in [issue 17](https://github.com/elixir-lsp/coc-elixir/issues/17)